### PR TITLE
chore: Add generic css reset styles

### DIFF
--- a/src/scss/_generic.foundation.scss
+++ b/src/scss/_generic.foundation.scss
@@ -1,0 +1,7 @@
+body {
+  margin: 0;
+}
+img {
+  max-width: 100%;
+  display: block;
+}

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -9,7 +9,7 @@
 @import "tools.colors";
 // SETTINGS
 // GENERIC
-
+@import "generic.foundation";
 
 // ELEMENTS
 


### PR DESCRIPTION
This commit removes the margin from the body element. It also defines the max-width of all images, and makes them block-level elements, to remove the default inline padding.

![screen shot 2018-09-06 at 4 46 42 pm](https://user-images.githubusercontent.com/4039311/45184267-7651a980-b1f4-11e8-98ad-8ea15075702b.png)


**To Test**

1. Pull down the branch
2. Run npm install
3. Run npm start
4. Navigate to http://localhost:3000/demo.html. Double-check that there are no margins on our demo content. 

