### PR TITLE
feat: add sales section

### DIFF
--- a/src/drizzle/data/contact.yaml
+++ b/src/drizzle/data/contact.yaml
@@ -1,0 +1,2 @@
+contactHeading: Carry a Modern Eden
+contactText: "Are you in search of rare finds like ours?  We’d love to talk about wholesale availability and pricing."

--- a/src/drizzle/data/stores.yaml
+++ b/src/drizzle/data/stores.yaml
@@ -1,0 +1,10 @@
+storeHeading: Or Find Us In the Wild
+storeList:
+  - storeTitle: Crate & Barrel
+    storeLocation: Multiple Chicago Locations
+    storeLinks: "Website | Map"
+  - storeTitle: "Rotofugi Designer Toy Store & Gallery"
+    storeLinks: "Website | Map"
+  - storeTitle: Acorn
+    storeLocation: "323 Atlantic Ave Brookyln, NY"
+    storeLinks: "Website | Map"

--- a/src/drizzle/pages/demo.hbs
+++ b/src/drizzle/pages/demo.hbs
@@ -10,3 +10,4 @@ layout: template
 {{> patterns.components.desert }}
 {{> patterns.components.deep-sea }}
 {{> patterns.components.accolades }}
+{{> patterns.components.contact-stores }}

--- a/src/drizzle/patterns/components/accolades.hbs
+++ b/src/drizzle/patterns/components/accolades.hbs
@@ -1,7 +1,7 @@
 ---
 title: Treasured Accolades
 ---
-<div class="theme__seafoam vert-spacing">
+<div class="theme-seafoam vert-spacing">
   <section class="accolades">
     <h3 class="accolades__heading">Treasured Accolades</h3>
     <p class="accolades__text">Winner of How Magazine’s 2011 International Design Awards</p>

--- a/src/drizzle/patterns/components/contact-stores.hbs
+++ b/src/drizzle/patterns/components/contact-stores.hbs
@@ -1,0 +1,39 @@
+<div class="theme-dusty-pink vert-spacing">
+  <div class="sales-group">
+    <section class="contact">
+      {{#with (data 'contact')}}
+      <h3 class="contact__heading">{{ contactHeading }}</h3>
+      <p class="contact__text">{{ contactText }}</p>
+      {{/with}}
+      <form class="contact-form"> 
+        <div class="contact-form__field">
+          <label class="contact-form__field--title" for="Name">Name</label>
+          <input class="contact-form__field--input" type="text" name="Name">
+        </div>
+        <div class="contact-form__field">
+          <label class="contact-form__field--title" for="Email Address">Email Address</label>
+          <input class="contact-form__field--input" type="text" name="Email Address">
+        </div>
+        <div class="contact-form__field">
+          <label class="contact-form__field--title" for="Message">Message</label>
+          <textarea class="contact-form__field--input contact-form__field--textarea" name="Message"></textarea>
+        </div>
+        <button class="contact-form__button" type="submit">Submit</button> 
+      </form>
+    </section>
+    <section class="stores">
+      {{#with (data 'stores')}}
+      <h4 class="stores__heading">{{ storeHeading }}</h4>
+      {{/with}}
+      <ul class="stores__list">
+        {{#each (data 'stores.storeList')}}
+        <li class="stores__item">
+          <h4 class="stores__title">{{ storeTitle }}</h4>
+          <p class="stores__text">{{ storeLocation }}</p>
+          <p class="stores__text">{{ storeLinks }}</p>
+        </li>
+        {{/each}}
+      </ul>
+    </section>
+  </div>
+</div>

--- a/src/drizzle/patterns/components/deep-sea.hbs
+++ b/src/drizzle/patterns/components/deep-sea.hbs
@@ -1,7 +1,7 @@
 ---
 title: Introduction
 ---
-<div class="theme__ocean">
+<div class="theme-ocean">
   <div class="env">
     <section class="env__story">
       <h2 class="env__heading">

--- a/src/drizzle/patterns/components/desert.hbs
+++ b/src/drizzle/patterns/components/desert.hbs
@@ -1,7 +1,7 @@
 ---
 title: Desert
 ---
-<div class="theme__desert">
+<div class="theme-desert">
   <div class="env env--desert">
     <section class="env__story">
       <h2 class="env__heading">

--- a/src/drizzle/patterns/components/intro.hbs
+++ b/src/drizzle/patterns/components/intro.hbs
@@ -1,7 +1,7 @@
 ---
 title: Introduction
 ---
-<div class="theme__mint">
+<div class="theme-mint">
   <article class="intro">
   {{> patterns.components.intro-illustration }}
     <section class="intro__body">

--- a/src/drizzle/patterns/components/polar.hbs
+++ b/src/drizzle/patterns/components/polar.hbs
@@ -1,7 +1,7 @@
 ---
 title: Polar
 ---
-<div class="theme__polar">
+<div class="theme-polar">
   <div class="env env--polar">
     <section class="env__story env__story--polar">
       <h2 class="env__heading">

--- a/src/scss/_components.contact.scss
+++ b/src/scss/_components.contact.scss
@@ -1,0 +1,134 @@
+.contact {
+  margin: 0 auto;
+  
+  @media (min-width: $section-breakpoint-md) {
+    flex: 1 0 70%; // Two-column layout
+    padding-right: 4rem; // Add space between the contact form and store list
+    box-sizing: border-box;
+  }
+
+  @media (min-width: $section-breakpoint-lg) {
+    padding-right: 6rem;
+  }
+
+  @media (min-width: $section-breakpoint-xl) {
+    padding-right: 8rem;
+  }
+
+  &__heading {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-size: 1.5rem;
+    text-transform: uppercase;
+    font-family: $heading;
+    text-align: center;
+    line-height: 1;
+
+    @media (min-width: $section-breakpoint-sm) {
+      text-align: left;
+    }
+    
+    @media (min-width: $section-breakpoint-md) {
+      font-size: 2.625rem;
+    }
+  
+    @media (min-width: $section-breakpoint-lg) {
+      font-size: 3.125rem;
+    }
+  }
+
+  &__text {
+    margin: 1rem 0 0;
+    box-sizing: border-box;
+    font-size: 1rem;
+    line-height: 1.5;
+    text-align: center;
+
+    @media (min-width: $section-breakpoint-sm) {
+      text-align: left;
+    }
+
+    @media (min-width: $section-breakpoint-md) {
+      font-size: 1.125rem;
+    }
+
+    @media (min-width: $section-breakpoint-lg) {
+      font-size: 1.3125rem;
+    }
+  }
+
+  &-form {
+    display: flex;
+    flex-direction: column;
+    margin: 1rem 0 0;
+    box-sizing: border-box;
+    
+    &__field {
+      margin: 0.5rem 0;
+      
+      &--title {
+        font-size: 1rem;
+        line-height: 1.5;
+        font-weight: bold;
+        text-transform: uppercase;
+        margin: 0;
+    
+        @media (min-width: $section-breakpoint-md) {
+          font-size: 1.125rem;
+        }
+    
+        @media (min-width: $section-breakpoint-lg) {
+          font-size: 1.3125rem;
+        }
+      }
+
+      &--input {
+        border: none;
+        width: 100%;
+        padding: 0.75rem;
+        margin: 0.5rem 0;
+        box-sizing: border-box;
+      }
+
+      &--textarea {
+        height: 10rem;
+        font-family: $body;
+      }
+    }
+
+    &__button {
+      border: none;
+      background: none;
+      padding: 0.5rem 1.75rem;
+      box-sizing: border-box;
+      border: 0.375rem solid $deep-purple;
+      font-size: 1rem;
+      line-height: 1.5;
+      color: $deep-purple;
+      font-family: $heading;
+      font-weight: bold;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      transition-property: background, color;
+      transition-duration: 0.3s; 
+      cursor: pointer;
+      margin: 1rem 0 0;
+
+      @media (min-width: $section-breakpoint-md) {
+        font-size: 1.125rem;
+        padding: 0.75rem 2rem;
+        align-self: flex-end;
+      }
+
+      @media (min-width: $section-breakpoint-lg) {
+        font-size: 1.3125rem;
+      }
+
+      &:hover {
+        background: $deep-purple;
+        color: $white;
+      }
+    }
+  }
+}

--- a/src/scss/_components.stores.scss
+++ b/src/scss/_components.stores.scss
@@ -1,0 +1,95 @@
+.stores {
+  margin: 3rem auto 0;
+
+  @media (min-width: $section-breakpoint-md) {
+    margin: 0 auto;
+    flex: 1 0 30%;
+  }
+
+  &__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+
+    @media (min-width: $section-breakpoint-sm) {
+      flex-direction: row;
+    }
+  }
+
+  &__item {
+    margin: 2rem 0 0;
+    flex: 1 0 100%;
+
+    @media (min-width: $section-breakpoint-sm) {
+      flex: 1 0 50%;
+      box-sizing: border-box;
+    }
+
+    @media (min-width: $section-breakpoint-md) {
+      flex: 1 0 100%;
+    }
+  }
+
+  &__heading {
+    text-transform: uppercase;
+    font-family: $heading;
+    font-weight: bold;
+    line-height: 1;
+    font-size: 1.5rem;
+    text-align: center;
+    margin: 0;
+
+    @media (min-width: $section-breakpoint-sm) {
+      text-align: left;
+    }
+
+    @media (min-width: $section-breakpoint-md) {
+      font-size: 1.75rem;
+    }
+
+    @media (min-width: $section-breakpoint-lg) {
+      font-size: 2rem;
+    }
+  }
+
+  &__text {
+    margin: 0;
+    font-size: 1rem;
+    line-height: 1.5;
+    text-align: center;
+
+    @media (min-width: $section-breakpoint-sm) {
+      text-align: left;
+    }
+
+    @media (min-width: $section-breakpoint-md) {
+      font-size: 1.125rem;
+    }
+
+    @media (min-width: $section-breakpoint-lg) {
+      font-size: 1.3125rem;
+    }
+  }
+
+  &__title {
+    margin: 0;
+    text-transform: uppercase;
+    font-size: 1rem;
+    line-height: 1.5;
+    text-align: center;
+
+    @media (min-width: $section-breakpoint-sm) {
+      text-align: left;
+    }
+
+    @media (min-width: $section-breakpoint-md) {
+      font-size: 1.125rem;
+    }
+
+    @media (min-width: $section-breakpoint-lg) {
+      font-size: 1.3125rem;
+    }
+  }
+}

--- a/src/scss/_objects.environment.scss
+++ b/src/scss/_objects.environment.scss
@@ -37,6 +37,14 @@
         padding: 18vh 0 12vh;
       }
     }
+
+    &--desert { // Desert needs additional space on top and bottom of the container
+      overflow: hidden; // We're defining this so we can push the tree off-screen
+
+      @media (min-width: $section-breakpoint-xs) {
+        padding: 18vh 0 12vh;
+      }
+    }
   }
 
   &__landscape {

--- a/src/scss/_objects.layout.scss
+++ b/src/scss/_objects.layout.scss
@@ -1,0 +1,14 @@
+.sales-group {
+  display: flex;
+  flex-direction: column;
+  width: 80%;
+  margin: 0 auto;
+
+  @media (min-width: $section-breakpoint-md) {
+    flex-direction: row; // Reset to default direction
+  }
+
+  @media (min-width: $section-breakpoint-xxl) {
+    width: 65%;
+  }
+}

--- a/src/scss/_objects.theme.scss
+++ b/src/scss/_objects.theme.scss
@@ -1,21 +1,23 @@
-.theme {
-    &__mint {
-        background: $mint;
-    }
+.theme-mint {
+  background: $mint;
+}
 
-    &__seafoam {
-        background: $seafoam;
-    }
+.theme-seafoam {
+  background: $seafoam;
+}
     
-    &__polar {
-        background: $polar;
-    }
+.theme-polar {
+  background: $polar;
+}
     
-    &__ocean {
-        background: $deep-sea-secondary;
-    }
+.theme-ocean {
+  background: $deep-sea-secondary;
+}
 
-    &__desert {
-        background: $sand;
-    }
+.theme-desert {
+  background: $sand;
+}
+
+.theme-dusty-pink {
+  background: $dusty-pink;
 }

--- a/src/scss/_tools.layout-variables.scss
+++ b/src/scss/_tools.layout-variables.scss
@@ -6,3 +6,4 @@ $section-breakpoint-sm: 44rem;
 $section-breakpoint-md: 60rem;
 $section-breakpoint-lg: 80rem;
 $section-breakpoint-xl: 90rem;
+$section-breakpoint-xxl: 95rem;

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -19,6 +19,7 @@
 // OBJECTS
 @import "objects.theme";
 @import "objects.environment";
+@import "objects.layout";
 
 // COMPONENTS
 @import "components.intro";
@@ -29,6 +30,8 @@
 @import "components.products";
 @import "components.accolades";
 @import "components.header";
+@import "components.contact";
+@import "components.stores";
 
 // UTILITIES
 @import "utilities.spacing-units";


### PR DESCRIPTION
### Description

This commit adds a sales section to the A Modern Eden website, which includes a contact form (for wholesale customers) and a store/stockist list (for retail customers).

### Spec

![screen shot 2018-09-19 at 8 50 48 am](https://user-images.githubusercontent.com/4039311/45754250-24902280-bbe9-11e8-82b7-073ba30ce8bc.png)

At large sizes, both sections – for retail and wholesale customers — should be displayed side-by-side in a two-column layout. 

![screen shot 2018-09-19 at 8 52 05 am](https://user-images.githubusercontent.com/4039311/45754314-52756700-bbe9-11e8-889f-3cba5444387e.png)

As real estate decreases at smaller sizes, the sales section should switch to a stacked layout, while still making the best of any available space. At these inbetween sizes, we'll present the store listing in a two-column layout. 

![screen shot 2018-09-19 at 8 54 26 am](https://user-images.githubusercontent.com/4039311/45754429-b009b380-bbe9-11e8-86bd-9ccf8e47f9a6.png)

We'll stack the list of stores in one list (and center the text) at the smallest, smartphone-oriented sizes.

#### To Validate

1. Pull down the branch
2. Run ```npm install```
3. Run ```npm start```
4. Navigate to http://localhost:3000/demo.html
5. Confirm that fonts load, and that: 
i.  Background color displays correctly
ii. Each element resizes as the viewport width or viewport height (or both) shrinks and grows.
iii. All text is readable 


