### PR TITLE
feat: footer section

### DIFF
--- a/src/drizzle/pages/demo.hbs
+++ b/src/drizzle/pages/demo.hbs
@@ -11,3 +11,4 @@ layout: template
 {{> patterns.components.deep-sea }}
 {{> patterns.components.accolades }}
 {{> patterns.components.contact-stores }}
+{{> patterns.components.footer }}

--- a/src/drizzle/patterns/components/footer.hbs
+++ b/src/drizzle/patterns/components/footer.hbs
@@ -1,0 +1,8 @@
+---
+title: Footer
+---
+
+<section class="footer theme-kraft-brown">
+  <p class="footer__text footer__text--emphasis">A Modern Eden is an inspired way to promote learning, play, and art appreciation.</p>  
+</section>
+<p class="footer__text">© 2011 – 2018 Forge LLC</p>

--- a/src/scss/_components.footer.scss
+++ b/src/scss/_components.footer.scss
@@ -1,0 +1,24 @@
+.footer {
+  &__text {
+    width: 90%; 
+    margin: 0 auto;
+    padding: 2rem 0;
+    box-sizing: border-box;
+    text-align: center;
+    font-size: 1rem;
+    line-height: 1.5;
+
+    @media (min-width: $section-breakpoint-md) {
+      font-size: 1.125rem;
+    }
+
+    @media (min-width: $section-breakpoint-lg) {
+      font-size: 1.3125rem;
+      padding: 2.8125rem 0;
+    }
+
+    &--emphasis {
+      font-weight: bold;
+    }
+  }
+}

--- a/src/scss/_objects.theme.scss
+++ b/src/scss/_objects.theme.scss
@@ -21,3 +21,7 @@
 .theme-dusty-pink {
   background: $dusty-pink;
 }
+
+.theme-kraft-brown {
+  background: $kraft-brown;
+}

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -32,6 +32,7 @@
 @import "components.header";
 @import "components.contact";
 @import "components.stores";
+@import "components.footer";
 
 // UTILITIES
 @import "utilities.spacing-units";


### PR DESCRIPTION
### Description 

This commit adds a footer section to the A Modern Eden website, which repeats what makes the brand special and includes some very brief copyright information. 

### Spec 

![screen shot 2018-09-19 at 9 21 52 am](https://user-images.githubusercontent.com/4039311/45755869-7aff6000-bbed-11e8-8fe1-17221d1bcc75.png)

### To Test

#### To Validate

1. Pull down the branch
2. Run ```npm install```
3. Run ```npm start```
4. Navigate to http://localhost:3000/demo.html
5. Does the text load? Does it resize to smaller font sizes at smaller viewport widths?
